### PR TITLE
docs(smoke): add diagnostics verification note and conclusions

### DIFF
--- a/SMOKE-DIAGNOSTICS-VERIFICATION-2026-04-05.md
+++ b/SMOKE-DIAGNOSTICS-VERIFICATION-2026-04-05.md
@@ -1,0 +1,48 @@
+# Smoke Diagnostics Verification Note (2026-04-05)
+
+## Scope
+This note summarizes CI verification work for smoke diagnostics summary and trend-window metrics.
+
+## Key Runs
+- Proof baseline (deterministic diagnostics-present): 23999344631
+  - URL: https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/23999344631
+  - Branch/SHA: ci-diagnostics-proof / dda37ba0dbb460dfbd5204e52e2ee50af9d11e4f
+  - Artifacts include `smoke-failure-diagnostics.json` and `smoke-trend-window.json`.
+  - Run annotations include notice:
+    - "Smoke Failure Diagnostics Summary Emitting Smoke Failure Diagnostics section to step summary from diagnostics artifact."
+
+- Normal main reference (completed workflow_dispatch): 23998693016
+  - URL: https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/23998693016
+  - Branch/SHA: main / 031a6e1b7e2cbcb6d7c8a0a7675af2590e4e0d0f
+
+- Fresh normal main attempt (stalled then completed failure): 23999474960
+  - URL: https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/23999474960
+  - Stalled in step: Run smoke suite
+  - Final status: completed with failure.
+
+## Trend Delta (Proof vs Fresh Main)
+Compared `smoke-trend-window.json` from proof run 23999344631 vs fresh normal main run 23999474960:
+
+- `freshDiagnosticsPresentRuns`: 0
+- `proofDiagnosticsPresentRuns`: 2
+- `deltaDiagnosticsPresentRuns`: +2
+- `freshDiagnosticsPresentRate`: 0.0
+- `proofDiagnosticsPresentRate`: 20.0
+- `deltaDiagnosticsPresentRate`: +20.0 points
+- `windowSize`: 10 in both runs
+
+Reference comparison against earlier completed normal run 23998693016 produced the same delta.
+
+## Branch Hygiene
+- Proof branch cleanup was pushed before deletion.
+- Local branch deleted: `ci-diagnostics-proof`
+- Remote branch deleted: `origin/ci-diagnostics-proof`
+
+## Notes
+- Verification on main is functionally blocked by intermittent run stalls during `Run smoke suite`.
+- Diagnostics tracking and summary emission behavior were validated in deterministic proof runs before branch cleanup.
+
+## Final Conclusion
+- Smoke diagnostics summary emission logic and trend-window diagnostics fields are verified as working.
+- Relative to a normal main run, diagnostics presence increased by 2 runs and 20.0 percentage points in the proof baseline window.
+- Remaining operational risk is runner stability in `Run smoke suite`; functional diagnostics logic is validated.


### PR DESCRIPTION
Add a short smoke diagnostics verification record with run IDs, trend-window delta, and final conclusion.