### PR TITLE
ci(actions): upgrade workflow actions for Node 24 runtime

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload preflight evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-preflight-reports
           path: |
@@ -115,10 +115,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload post-deploy verification evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-postdeploy-evidence
           path: release-evidence/
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run rollback dry run
         shell: pwsh
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload rollback dry-run evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-rollback-dry-run
           path: release-evidence/

--- a/.github/workflows/smoke-suite.yml
+++ b/.github/workflows/smoke-suite.yml
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -73,7 +73,7 @@ jobs:
             backend/package-lock.json
 
       - name: Restore smoke trend history
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: qa-reports/smoke-trend-history.json
           key: smoke-trend-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -864,7 +864,7 @@ jobs:
 
       - name: Save smoke trend history
         if: always() && hashFiles('qa-reports/smoke-trend-history.json') != ''
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: qa-reports/smoke-trend-history.json
           key: smoke-trend-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -889,7 +889,7 @@ jobs:
 
       - name: Upload smoke suite reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-${{ github.event_name }}-reports
           path: qa-reports/


### PR DESCRIPTION
## Summary
- upgrade checkout to actions/checkout@v6
- upgrade setup-node to actions/setup-node@v6
- upgrade upload-artifact to actions/upload-artifact@v7
- upgrade smoke cache actions to actions/cache/restore@v5 and actions/cache/save@v5
- apply updates in smoke-suite and release-guardrails workflows

## Validation
- workflow files parse cleanly (no editor errors)