### PR TITLE
fix(ci): correct rollback dry-run parameter passing

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Run rollback dry run
         shell: pwsh
         run: |
-          npm run release:rollback:dry -- --reason="GitHub Actions release guardrail dry run for ${{ github.sha }}"
+          powershell -ExecutionPolicy Bypass -File .\release-rollback-dry-run.ps1 -Reason "GitHub Actions release guardrail dry run for ${{ github.sha }}"
 
       - name: Upload rollback dry-run evidence
         if: always()


### PR DESCRIPTION
## Summary
- update release-guardrails rollback step to invoke release-rollback-dry-run.ps1 directly
- pass reason using -Reason parameter format expected by the script

## Why
The previous npm argument form passed --reason=... which PowerShell treated as an invalid parameter name.