### PR TITLE
fix(ci): set rollback checkout fetch-depth to 2

### DIFF
--- a/.github/workflows/release-guardrails.yml
+++ b/.github/workflows/release-guardrails.yml
@@ -152,6 +152,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Run rollback dry run
         shell: pwsh


### PR DESCRIPTION
## Summary
- configure rollback-dry-run checkout step with fetch-depth: 2
- ensures release-rollback-dry-run.ps1 can resolve HEAD~1 on CI clone