### PR TITLE
chore(copilot): enable automatic copilot task intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/copilot-auto-task.yml
+++ b/.github/ISSUE_TEMPLATE/copilot-auto-task.yml
@@ -1,0 +1,76 @@
+name: Copilot Auto Task
+description: Structured task format for automatic Copilot intake and execution handoff.
+title: "copilot: "
+labels:
+  - copilot-auto
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill all required sections so intake automation can mark this issue as Copilot ready.
+
+  - type: input
+    id: goal
+    attributes:
+      label: Goal
+      description: One line outcome for this task.
+      placeholder: Example: Fix smoke workflow failure in schema validation step.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Files, modules, or workflows that should be touched.
+      placeholder: |
+        - .github/workflows/smoke-suite.yml
+        - smoke-validate-artifacts.ps1
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Measurable done conditions.
+      placeholder: |
+        - Workflow run succeeds on main
+        - Schema validation step passes
+        - No regression in visual baseline verification
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation Commands
+      description: Commands that prove the change works.
+      value: |
+        npm run smoke
+        npm run smoke:baseline:verify
+      render: shell
+    validations:
+      required: true
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk Level
+      options:
+        - Low
+        - Medium
+        - High
+      default: 0
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety Checks
+      options:
+        - label: I confirmed this task does not require committing secrets.
+          required: true
+        - label: I confirmed this task does not require destructive git history changes.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# ElectroMart Copilot Instructions
+
+## Project Shape
+- Frontend is static HTML, CSS, and JS at repository root.
+- Backend API lives in backend/src and runs with Express.
+- QA and release automation live in root PowerShell and Node scripts.
+
+## High-Value Entry Points
+- Smoke orchestration: qa-full-smoke.js
+- UI smoke snapshots: qa-ui-smoke.js
+- Smoke workflow: .github/workflows/smoke-suite.yml
+- Release workflow: .github/workflows/release-guardrails.yml
+- Backend entrypoint: backend/src/server.js
+
+## Non-Negotiables During Edits
+- Preserve existing page IDs and hooks used by script.js and smoke tests.
+- Do not remove or rename QA artifact schemas without updating validators.
+- Keep backend environment handling compatible with backend/.env.example.
+- Avoid unrelated formatting-only changes in large static page files.
+
+## Validation Matrix
+- Frontend, smoke, or workflow changes:
+  - npm ci
+  - npm run smoke
+  - npm run smoke:baseline:verify
+- Backend-only logic changes:
+  - npm.cmd --prefix backend run test:unit
+  - npm.cmd --prefix backend run start (or dev) for manual sanity
+- Release guardrail changes:
+  - npm run release:preflight
+  - npm run release:rollback:dry
+
+## CI and Governance Expectations
+- Keep workflow action majors on current baselines:
+  - actions/checkout v6
+  - actions/setup-node v6
+  - actions/upload-artifact v7
+  - actions/cache restore and save v5
+- Keep smoke and release workflows green before merge.
+
+## Commit and PR Style
+- Prefer small focused commits with prefixes like fix(...), ci(...), chore(...), docs(...).
+- Include concise validation evidence in PR descriptions.
+- Never commit secrets or environment tokens.

--- a/.github/workflows/copilot-auto-intake.yml
+++ b/.github/workflows/copilot-auto-intake.yml
@@ -1,0 +1,151 @@
+name: Copilot Auto Intake
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: copilot-auto-intake-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  intake:
+    if: contains(github.event.issue.labels.*.name, 'copilot-auto')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate issue structure and update labels
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- copilot-auto-intake -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue.number;
+            const issueBody = (context.payload.issue.body || '').toLowerCase();
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            await ensureLabel('copilot-auto', '0052cc', 'Task intended for Copilot auto intake');
+            await ensureLabel('copilot-ready', '0e8a16', 'Task has required structure and is ready for Copilot handoff');
+            await ensureLabel('copilot-needs-info', 'd93f0b', 'Task is missing required structure for Copilot handoff');
+
+            const requiredSections = [
+              { key: 'Goal', patterns: ['## goal', '### goal'] },
+              { key: 'Scope', patterns: ['## scope', '### scope'] },
+              { key: 'Acceptance Criteria', patterns: ['## acceptance criteria', '### acceptance criteria'] },
+              { key: 'Validation Commands', patterns: ['## validation commands', '### validation commands'] }
+            ];
+
+            const missing = requiredSections
+              .filter((section) => !section.patterns.some((pattern) => issueBody.includes(pattern)))
+              .map((section) => section.key);
+
+            const currentLabels = (context.payload.issue.labels || []).map((label) => label.name);
+            const desiredLabels = ['copilot-auto'];
+            if (missing.length === 0) {
+              desiredLabels.push('copilot-ready');
+            } else {
+              desiredLabels.push('copilot-needs-info');
+            }
+
+            const labelsToAdd = desiredLabels.filter((name) => !currentLabels.includes(name));
+            const labelsToRemove = ['copilot-ready', 'copilot-needs-info']
+              .filter((name) => !desiredLabels.includes(name) && currentLabels.includes(name));
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                labels: labelsToAdd
+              });
+            }
+
+            for (const name of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            const readyMessage = `${marker}
+            ## Copilot Intake Ready
+
+            This issue has the required structure and is ready for Copilot-driven execution.
+
+            Recommended flow:
+            1. Keep label copilot-auto.
+            2. Delegate the issue to Copilot coding agent from GitHub issue UI.
+            3. Review generated PR against acceptance criteria.
+            4. Merge only after smoke and release checks pass.
+
+            Default validation command set:
+            - npm run smoke
+            - npm run smoke:baseline:verify
+            - npm run release:preflight
+            `;
+
+            const needsInfoMessage = `${marker}
+            ## Copilot Intake Needs Info
+
+            This issue is missing required sections and cannot be auto-marked ready.
+
+            Missing sections:
+            ${missing.map((name) => `- ${name}`).join('\n')}
+
+            Please update the issue using the Copilot Auto Task template, then re-save.
+            `;
+
+            const commentBody = missing.length === 0 ? readyMessage : needsInfoMessage;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100
+            });
+
+            const existing = comments.find((comment) => {
+              return comment.user && comment.user.type === 'Bot' && (comment.body || '').includes(marker);
+            });
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: commentBody
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ GitHub Actions smoke workflow:
 
 - [.github/workflows/smoke-suite.yml](./.github/workflows/smoke-suite.yml)
 - [.github/workflows/release-guardrails.yml](./.github/workflows/release-guardrails.yml)
+- [.github/workflows/copilot-auto-intake.yml](./.github/workflows/copilot-auto-intake.yml)
+
+Copilot automatic task intake:
+
+- Project coding instructions: [.github/copilot-instructions.md](./.github/copilot-instructions.md)
+- Structured issue template: [.github/ISSUE_TEMPLATE/copilot-auto-task.yml](./.github/ISSUE_TEMPLATE/copilot-auto-task.yml)
+- Use label `copilot-auto` to trigger intake automation
+- Intake workflow auto-manages `copilot-ready` and `copilot-needs-info` labels based on issue structure
+- After issue is marked ready, delegate from GitHub issue UI to Copilot coding agent
 
 Required repository secret:
 


### PR DESCRIPTION
## Summary
- add repo level copilot instructions
- add copilot task issue template with required sections
- add issue driven copilot auto intake workflow with label management
- document copilot intake flow in README

## Validation
- workspace diagnostics report no errors in new files