### PR TITLE
chore(audit): automate weekly Amazon-style A2Z cadence

### DIFF
--- a/.github/workflows/a2z-weekly-audit-intake.yml
+++ b/.github/workflows/a2z-weekly-audit-intake.yml
@@ -1,0 +1,145 @@
+name: A2Z Weekly Audit Intake
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: a2z-weekly-audit-intake-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  create-weekly-audit-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or reuse weekly A2Z audit issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (error) {
+                if (error.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            await ensureLabel('copilot-auto', '0052cc', 'Task intended for Copilot auto intake');
+            await ensureLabel('audit-weekly', '5319e7', 'Weekly Amazon-style A-to-Z audit tracker');
+
+            const now = new Date();
+            const utc = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+            const day = utc.getUTCDay();
+            const mondayDelta = day === 0 ? -6 : 1 - day;
+            const monday = new Date(utc);
+            monday.setUTCDate(utc.getUTCDate() + mondayDelta);
+            const weekKey = monday.toISOString().slice(0, 10);
+
+            const title = `copilot: weekly a2z audit ${weekKey}`;
+
+            const openWeeklyIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'audit-weekly',
+              per_page: 100
+            });
+
+            const existing = openWeeklyIssues.find((issue) => {
+              const issueTitle = (issue.title || '').toLowerCase();
+              return issueTitle.includes(`weekly a2z audit ${weekKey}`);
+            });
+
+            if (existing) {
+              core.notice(`Weekly audit issue already exists: #${existing.number}`);
+              return;
+            }
+
+            const bodyLines = [
+              '## Goal',
+              'Run Amazon-style A-to-Z weekly audit, compute completion percentage, and close remaining percentage as one execution phase.',
+              '',
+              '## Scope',
+              '- Branch protection and merge governance',
+              '- Smoke, release, and workflow governance CI health',
+              '- Backend unit-test and dependency-security posture',
+              '- Production hardening and runbook/document freshness',
+              '- Copilot automation intake and execution readiness',
+              '',
+              '## Acceptance Criteria',
+              '- Publish weighted done percentage and remaining percentage.',
+              '- Publish domain score table with evidence links.',
+              '- Execute remaining percentage in one closure phase.',
+              '- Recompute final percentage after closure and record outcome.',
+              '',
+              '## Validation Commands',
+              '```powershell',
+              'npm run branch:protect:check',
+              'npm.cmd --prefix backend run test:unit',
+              'npm.cmd --prefix backend audit',
+              'gh run list --workflow smoke-suite.yml --limit 1',
+              'gh run list --workflow release-guardrails.yml --limit 1',
+              'gh run list --workflow workflow-action-governance.yml --limit 1',
+              '```',
+              '',
+              '## A-to-Z Checklist',
+              '- [ ] A. Access and permissions health',
+              '- [ ] B. Branch protection and merge controls',
+              '- [ ] C. CI status trend and gate reliability',
+              '- [ ] D. Dependency vulnerabilities and remediation status',
+              '- [ ] E. Environment policy and secret safety checks',
+              '- [ ] F. Feature coverage review',
+              '- [ ] G. Governance workflow health',
+              '- [ ] H. Hardening checklist closure state',
+              '- [ ] I. Incident runbook currency',
+              '- [ ] J. Job automation health',
+              '- [ ] K. Key release evidence recency',
+              '- [ ] L. Logging and metrics readiness',
+              '- [ ] M. Monitoring and alerting confidence',
+              '- [ ] N. Notification and escalation readiness',
+              '- [ ] O. Operational rollback readiness',
+              '- [ ] P. Production policy compliance',
+              '- [ ] Q. QA pass rate (unit plus smoke)',
+              '- [ ] R. Release guardrails status',
+              '- [ ] S. Security posture snapshot',
+              '- [ ] T. Test evidence completeness',
+              '- [ ] U. UI baseline integrity',
+              '- [ ] V. Validation reproducibility',
+              '- [ ] W. Workflow action governance',
+              '- [ ] X. Cross-document consistency',
+              '- [ ] Y. Week-over-week trend note',
+              '- [ ] Z. Zero-blocker sign-off',
+              '',
+              '## Scoring Model',
+              '- Feature completeness: 25',
+              '- Backend unit tests: 20',
+              '- Smoke and release CI health: 20',
+              '- Production hardening checklist: 15',
+              '- Branch governance: 10',
+              '- Dependency security: 5',
+              '- Documentation freshness: 5'
+            ];
+
+            const body = bodyLines.join('\n');
+
+            const created = await github.rest.issues.create({
+              owner,
+              repo,
+              title,
+              body,
+              labels: ['copilot-auto', 'audit-weekly']
+            });
+
+            core.notice(`Created weekly A2Z audit issue #${created.data.number}`);

--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ GitHub Actions smoke workflow:
 - [.github/workflows/release-guardrails.yml](./.github/workflows/release-guardrails.yml)
 - [.github/workflows/copilot-auto-intake.yml](./.github/workflows/copilot-auto-intake.yml)
 - [.github/workflows/workflow-action-governance.yml](./.github/workflows/workflow-action-governance.yml)
+- [.github/workflows/a2z-weekly-audit-intake.yml](./.github/workflows/a2z-weekly-audit-intake.yml)
 
 Workflow action major guardrail:
 
@@ -357,6 +358,12 @@ Copilot automatic task intake:
 - Use label `copilot-auto` to trigger intake automation
 - Intake workflow auto-manages `copilot-ready` and `copilot-needs-info` labels based on issue structure
 - After issue is marked ready, delegate from GitHub issue UI to Copilot coding agent
+
+Amazon-style weekly A-to-Z audit cadence:
+
+- Audit playbook: [docs/AMAZON-A2Z-AUDIT-CADENCE.md](./docs/AMAZON-A2Z-AUDIT-CADENCE.md)
+- Weekly intake workflow creates one structured `copilot: weekly a2z audit <week>` issue
+- Weekly issue is auto-labeled for Copilot intake and uses the weighted percentage model
 
 Required repository secret:
 

--- a/docs/AMAZON-A2Z-AUDIT-CADENCE.md
+++ b/docs/AMAZON-A2Z-AUDIT-CADENCE.md
@@ -1,0 +1,84 @@
+# Amazon-Style A-to-Z Weekly Audit Cadence
+
+Last updated: April 5, 2026
+
+## Purpose
+
+Run one disciplined weekly audit cycle that measures completion in percentage terms, isolates the exact remaining gap, and closes that gap as a single execution phase.
+
+## Cadence
+
+- Frequency: weekly
+- Trigger: Monday intake issue (auto-created by workflow)
+- Delivery model: one owner, one evidence set, one closure PR
+
+## Single-Phase Closure Rule
+
+1. Compute weighted completion percentage.
+2. Convert remaining percentage into one consolidated closure phase.
+3. Execute closure phase end-to-end.
+4. Recompute and publish final completion score.
+
+## A-to-Z Audit Sequence
+
+- A. Access and permissions health
+- B. Branch protection and merge controls
+- C. CI status trend and gate reliability
+- D. Dependency vulnerabilities and remediation status
+- E. Environment policy and secret safety checks
+- F. Feature coverage (storefront and admin)
+- G. Governance workflows health
+- H. Hardening checklist closure
+- I. Incident runbook currency
+- J. Job automation health
+- K. Key release evidence recency
+- L. Logging and metrics readiness
+- M. Monitoring and alerting confidence
+- N. Notification and escalation readiness
+- O. Operational rollback readiness
+- P. Production policy compliance
+- Q. QA pass rate (unit plus smoke)
+- R. Release guardrails status
+- S. Security posture snapshot
+- T. Test evidence completeness
+- U. UI baseline integrity
+- V. Validation reproducibility
+- W. Workflow action governance
+- X. Cross-document consistency
+- Y. Year-over-year and week-over-week trend note
+- Z. Zero-blocker sign-off
+
+## Scoring Model
+
+Use this weighted model for weekly percentage reporting:
+
+- Feature completeness: 25
+- Backend unit tests: 20
+- Smoke and release CI health: 20
+- Production hardening checklist: 15
+- Branch governance: 10
+- Dependency security: 5
+- Documentation freshness: 5
+
+Total weight: 100
+
+## Minimum Evidence Set
+
+- Branch protection check output
+- Backend unit-test summary
+- Backend dependency audit summary
+- Latest smoke workflow result
+- Latest release guardrails workflow result
+- Latest governance workflow result
+- Latest copilot-intake automation result
+- Updated project audit summary
+
+## Output Contract
+
+Each weekly issue must publish:
+
+1. Done percentage
+2. Remaining percentage
+3. Domain-wise score table
+4. Exact closure tasks for remaining percentage
+5. Final post-closure percentage update


### PR DESCRIPTION
## Summary
- add weekly A2Z audit cadence playbook
- add scheduled A2Z weekly intake workflow to create Copilot-ready audit issue
- document cadence workflow in README

## Validation
- YAML and markdown diagnostics clean