### PR TITLE
ops: automate weekly audit evidence snapshot for issue #36

### DIFF
--- a/PRODUCTION-HARDENING-BACKLOG.md
+++ b/PRODUCTION-HARDENING-BACKLOG.md
@@ -33,7 +33,7 @@ Move from "demo-safe" operations to production-grade operational safety with exp
 ## Weekly Risk Triage (Week of April 13, 2026)
 
 1. `R-01` CI evidence drift risk: manual audit updates can lag latest workflow results.
-   Owner: `@chouhantrade1986-glitch`. Mitigation task: [Issue #36](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/36).
+   Owner: `@chouhantrade1986-glitch`. Latest mitigation completed in [Issue #36](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/36).
 2. `R-02` Release evidence cadence risk: `release-guardrails` runs remain manually triggered and can be skipped.
    Owner: `@chouhantrade1986-glitch`. Latest mitigation completed in [Issue #35](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/35).
 3. `R-03` Alert threshold drift risk: current thresholds need periodic recalibration against recent traffic.

--- a/PROJECT-AUDIT.md
+++ b/PROJECT-AUDIT.md
@@ -21,6 +21,7 @@ Last updated: April 6, 2026
 - Backend dependency audit: **0 vulnerabilities** (`npm.cmd --prefix backend audit --audit-level=high`, April 6, 2026)
 - Alert threshold baseline review: **completed** ([Issue #34](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/34), April 6, 2026)
 - Weekly release-guardrails cadence policy: **completed** ([Issue #35](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/35), April 6, 2026)
+- Weekly audit evidence automation: **completed** ([Issue #36](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/36), April 6, 2026; command `npm run audit:evidence:weekly`)
 
 ## Weighted Audit Breakdown
 
@@ -32,14 +33,14 @@ Last updated: April 6, 2026
 | Production readiness | 10 / 10 |
 | **Total** | **98 / 100** |
 
-## Remaining Backlog (1%)
+## Remaining Backlog (0%)
 
-1. Automate weekly audit evidence snapshot publishing to avoid stale run links. Owner: `@chouhantrade1986-glitch`. Tracking: [Issue #36](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/36).
+1. No blocking backlog item remains in the current audit scope.
 
 ## Step-by-Step Next Sequence
 
 1. Keep branch protection and workflow-governance checks green on each change.
-2. Complete [Issue #36](https://github.com/chouhantrade1986-glitch/Electronic-Store/issues/36) to automate evidence snapshot generation before the next weekly audit cycle.
+2. Run `npm run audit:evidence:weekly` at the start of each weekly audit cycle and paste snippet output into the evidence section.
 3. Keep weekly release-guardrails runs current in [RELEASE-GUARDRAILS.md](./RELEASE-GUARDRAILS.md) cadence records.
 4. Re-run the alert threshold baseline review in the week of April 13, 2026 using [docs/ALERT-THRESHOLD-BASELINE-REVIEW-2026-04-06.md](./docs/ALERT-THRESHOLD-BASELINE-REVIEW-2026-04-06.md).
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Electronic Store is a storefront and admin dashboard built with static HTML/CSS/
 
 ## Project Audit Status (April 6, 2026)
 
-- Completed: **99%**
-- Remaining: **1%**
+- Completed: **100%**
+- Remaining: **0%**
 - Detailed report and owner-assigned follow-ups: [PROJECT-AUDIT.md](./PROJECT-AUDIT.md)
 
 ## Main Areas
@@ -119,6 +119,12 @@ cd backend
 npm run job:alerts:check
 npm run job:alerts:check -- --fail-on-alert
 npm run job:alerts:check -- --api-base-url=http://127.0.0.1:4000/api
+```
+
+Weekly audit evidence snippet generation:
+
+```powershell
+npm run audit:evidence:weekly
 ```
 
 Alert runbook reference:

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release:preflight": "powershell -ExecutionPolicy Bypass -File .\\release-preflight.ps1",
     "release:verify:postdeploy": "npm.cmd --prefix backend run job:release:verify --",
     "release:rollback:dry": "powershell -ExecutionPolicy Bypass -File .\\release-rollback-dry-run.ps1",
+    "audit:evidence:weekly": "powershell -ExecutionPolicy Bypass -File .\\scripts\\ci\\generate-weekly-audit-evidence.ps1",
     "cleanup:artifacts": "powershell -ExecutionPolicy Bypass -File .\\cleanup-generated-artifacts.ps1 -Apply",
     "cleanup:artifacts:dry": "powershell -ExecutionPolicy Bypass -File .\\cleanup-generated-artifacts.ps1",
     "branch:protect:main": "powershell -ExecutionPolicy Bypass -File .\\set-main-branch-protection.ps1",

--- a/scripts/ci/generate-weekly-audit-evidence.ps1
+++ b/scripts/ci/generate-weekly-audit-evidence.ps1
@@ -1,0 +1,100 @@
+[CmdletBinding()]
+param(
+  [string]$Repository = "chouhantrade1986-glitch/Electronic-Store",
+  [string[]]$Workflows = @(
+    "smoke-suite.yml",
+    "release-guardrails.yml",
+    "workflow-action-governance.yml",
+    "a2z-weekly-audit-intake.yml"
+  ),
+  [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = (Resolve-Path (Join-Path $scriptDir "../..")).Path
+
+function Resolve-OutputPath {
+  param(
+    [AllowEmptyString()]
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return ""
+  }
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return $Path
+  }
+
+  return Join-Path $repoRoot $Path
+}
+
+function Get-LatestWorkflowRun {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Repo,
+    [Parameter(Mandatory = $true)]
+    [string]$Workflow
+  )
+
+  $headers = @{
+    "User-Agent" = "ElectroMart-Weekly-Audit-Evidence"
+    "Accept" = "application/vnd.github+json"
+  }
+
+  $uri = "https://api.github.com/repos/$Repo/actions/workflows/$Workflow/runs?per_page=1"
+  $response = Invoke-RestMethod -Uri $uri -Headers $headers
+  $run = @($response.workflow_runs)[0]
+  if ($null -eq $run) {
+    throw "No workflow runs found for '$Workflow'."
+  }
+
+  return [pscustomobject]@{
+    workflow = $Workflow
+    run_number = [int]$run.run_number
+    status = [string]$run.status
+    conclusion = [string]$run.conclusion
+    created_at = [string]$run.created_at
+    html_url = [string]$run.html_url
+  }
+}
+
+$rows = @()
+foreach ($workflow in $Workflows) {
+  $rows += Get-LatestWorkflowRun -Repo $Repository -Workflow $workflow
+}
+
+$generatedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+$lines = @(
+  "## Weekly CI Evidence Snapshot ($generatedAt)",
+  "",
+  "| Workflow | Run | Status | Created (UTC) |",
+  "| --- | --- | --- | --- |"
+)
+
+foreach ($row in $rows) {
+  $statusLabel = if ([string]::IsNullOrWhiteSpace($row.conclusion)) {
+    $row.status
+  } else {
+    "$($row.status) / $($row.conclusion)"
+  }
+
+  $lines += "| ``$($row.workflow)`` | [run $($row.run_number)]($($row.html_url)) | $statusLabel | $($row.created_at) |"
+}
+
+$snippet = $lines -join [Environment]::NewLine
+
+$resolvedOutputPath = Resolve-OutputPath -Path $OutputPath
+if (-not [string]::IsNullOrWhiteSpace($resolvedOutputPath)) {
+  $outputDirectory = Split-Path -Parent $resolvedOutputPath
+  if (-not [string]::IsNullOrWhiteSpace($outputDirectory)) {
+    New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+  }
+  Set-Content -Path $resolvedOutputPath -Value ($snippet + [Environment]::NewLine) -Encoding utf8
+  Write-Host "Weekly audit evidence snippet written to: $resolvedOutputPath"
+}
+
+Write-Output $snippet


### PR DESCRIPTION
## Summary
- add `scripts/ci/generate-weekly-audit-evidence.ps1` to fetch latest workflow run metadata and render a markdown snippet
- add one-command entrypoint: `npm run audit:evidence:weekly`
- update docs to reference the automation path and close evidence-drift mitigation
- align audit status to reflect completed weekly operational backlog

## Acceptance Coverage (Issue #36)
- [x] One command generates weekly evidence snippet (`npm run audit:evidence:weekly`)
- [x] Snippet includes run URL, run number, status, and created_at
- [x] Documentation references automation path in `PROJECT-AUDIT.md`

## Validation
- `npm run audit:evidence:weekly` (success)
- file diagnostics on changed files (no errors)

Closes #36