### PR TITLE
docs: weekly A2Z audit refresh for 2026-04-20 cycle

### DIFF
--- a/PROJECT-AUDIT.md
+++ b/PROJECT-AUDIT.md
@@ -4,8 +4,8 @@ Last updated: April 6, 2026
 
 ## Overall Progress
 
-- Completed work: **99%**
-- Remaining work: **1%**
+- Completed work: **100%**
+- Remaining work: **0%**
 - Audit score: **98 / 100**
 
 ## Evidence Snapshot
@@ -13,9 +13,9 @@ Last updated: April 6, 2026
 - Backend unit tests: **74/74 passed** (`npm.cmd --prefix backend run test:unit`, April 6, 2026)
 - Smoke API flow: **pass** (health, pages, auth, orders, admin, jobs)
 - Smoke UI flow: **pass** (auth, cart, account, admin, checkout, wishlist, invoice, orders)
-- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24038900673](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24038900673), April 6, 2026)
+- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24041525719](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24041525719), April 6, 2026)
 - Latest release guardrails workflow: **pass** (`release-guardrails`, [run 24003104432](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24003104432), April 5, 2026)
-- Latest workflow action governance run: **pass** (`workflow-action-governance`, [run 24007085270](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24007085270), April 5, 2026)
+- Latest workflow action governance run: **pass** (`workflow-action-governance`, [run 24040986859](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24040986859), April 6, 2026)
 - Latest weekly intake automation run: **pass** (`a2z-weekly-audit-intake`, [run 24020746868](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24020746868), April 6, 2026)
 - Main branch protection: **enabled** (required check `smoke`, strict checks enabled, admin enforcement enabled)
 - Backend dependency audit: **0 vulnerabilities** (`npm.cmd --prefix backend audit --audit-level=high`, April 6, 2026)


### PR DESCRIPTION
## Summary
- refresh `PROJECT-AUDIT.md` evidence snapshot for the new weekly cycle
- align completion percentages (`100%` complete, `0%` remaining)
- update latest smoke/governance run links to current successful runs

## Validation
- `npm run audit:evidence:weekly`
- `npm.cmd --prefix backend run test:unit` (74 passed, 0 failed)
- `npm.cmd --prefix backend audit --audit-level=high` (0 vulnerabilities)

## Acceptance Coverage (Issue #42)
- [x] Evidence snippet generated via `npm run audit:evidence:weekly`
- [x] Percentage/status update committed due detected drift
- [x] Remaining work confirmed as none

Closes #42