### PR TITLE
docs: refresh weekly A2Z audit evidence for 2026-05-04 (#79)

### DIFF
--- a/PROJECT-AUDIT.md
+++ b/PROJECT-AUDIT.md
@@ -13,7 +13,7 @@ Last updated: April 6, 2026
 - Backend unit tests: **74/74 passed** (`npm.cmd --prefix backend run test:unit`, April 6, 2026)
 - Smoke API flow: **pass** (health, pages, auth, orders, admin, jobs)
 - Smoke UI flow: **pass** (auth, cart, account, admin, checkout, wishlist, invoice, orders)
-- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24062275653](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24062275653), April 7, 2026)
+- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24063035590](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24063035590), April 7, 2026)
 - Latest release guardrails workflow: **pass** (`release-guardrails`, [run 24003104432](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24003104432), April 5, 2026)
 - Latest workflow action governance run: **pass** (`workflow-action-governance`, [run 24040986859](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24040986859), April 6, 2026)
 - Latest weekly intake automation run: **pass** (`a2z-weekly-audit-intake`, [run 24020746868](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24020746868), April 6, 2026)


### PR DESCRIPTION
## Summary
- refresh `PROJECT-AUDIT.md` with the latest successful `smoke-suite` workflow run for the weekly 2026-05-04 cycle

## Validation
- `npm.cmd run audit:evidence:weekly`
- `npm.cmd --prefix backend ci`
- `npm.cmd --prefix backend run test:unit` (74/74 pass)
- `npm.cmd --prefix backend audit --audit-level=high` (0 vulnerabilities)

Closes #79