### PR TITLE
chore(audit): weekly A2Z audit refresh for 2026-10-05

### DIFF
--- a/PROJECT-AUDIT.md
+++ b/PROJECT-AUDIT.md
@@ -13,7 +13,7 @@ Last updated: April 7, 2026
 - Backend unit tests: **74/74 passed** (`npm.cmd --prefix backend run test:unit`, April 6, 2026)
 - Smoke API flow: **pass** (health, pages, auth, orders, admin, jobs)
 - Smoke UI flow: **pass** (auth, cart, account, admin, checkout, wishlist, invoice, orders)
-- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24097192274](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24097192274), April 7, 2026)
+- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24097971556](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24097971556), April 7, 2026)
 - Latest release guardrails workflow: **pass** (`release-guardrails`, [run 24003104432](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24003104432), April 5, 2026)
 - Latest workflow action governance run: **pass** (`workflow-action-governance`, [run 24040986859](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24040986859), April 6, 2026)
 - Latest weekly intake automation run: **pass** (`a2z-weekly-audit-intake`, [run 24020746868](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24020746868), April 6, 2026)


### PR DESCRIPTION
## Summary
- refresh weekly audit evidence snapshot in PROJECT-AUDIT.md
- update latest successful smoke-suite workflow run reference to current run
- keep weekly cadence artifacts aligned for the 2026-10-05 cycle

## Validation
- npm run audit:evidence:weekly
- npm.cmd --prefix backend ci
- npm.cmd --prefix backend run test:unit (74/74 passed)
- npm.cmd --prefix backend audit --audit-level=high (0 vulnerabilities)

Closes #125