### PR TITLE
docs(audit): refresh weekly smoke evidence (2026-12-21)

### DIFF
--- a/PROJECT-AUDIT.md
+++ b/PROJECT-AUDIT.md
@@ -13,7 +13,7 @@ Last updated: April 7, 2026
 - Backend unit tests: **74/74 passed** (`npm.cmd --prefix backend run test:unit`, April 6, 2026)
 - Smoke API flow: **pass** (health, pages, auth, orders, admin, jobs)
 - Smoke UI flow: **pass** (auth, cart, account, admin, checkout, wishlist, invoice, orders)
-- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24122861118](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24122861118), April 8, 2026)
+- Latest CI smoke workflow: **pass** (`smoke-suite`, [run 24227547183](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24227547183), April 10, 2026)
 - Latest release guardrails workflow: **pass** (`release-guardrails`, [run 24003104432](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24003104432), April 5, 2026)
 - Latest workflow action governance run: **pass** (`workflow-action-governance`, [run 24040986859](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24040986859), April 6, 2026)
 - Latest weekly intake automation run: **pass** (`a2z-weekly-audit-intake`, [run 24020746868](https://github.com/chouhantrade1986-glitch/Electronic-Store/actions/runs/24020746868), April 6, 2026)


### PR DESCRIPTION
## Summary
- refresh weekly audit evidence snapshot in PROJECT-AUDIT.md
- update latest CI smoke workflow reference to the newest successful run

## Validation
- npm run audit:evidence:weekly
- npm.cmd --prefix backend ci
- npm.cmd --prefix backend run test:unit
- npm.cmd --prefix backend audit --audit-level=high

## Result
- backend unit tests: 74/74 pass
- backend audit: 0 vulnerabilities
- latest smoke-suite run: 24227547183 (success)

Closes #193